### PR TITLE
Stop invoke initAppOps in Camera default constructor.

### DIFF
--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -657,9 +657,7 @@ public class Camera {
     /**
      * An empty Camera for testing purpose.
      */
-    Camera() {
-        initAppOps();
-    }
+    Camera() {}
 
     private void initAppOps() {
         IBinder b = ServiceManager.getService(Context.APP_OPS_SERVICE);


### PR DESCRIPTION
Camera default constructor does not create the underlying native camera
object. Thus calling _enableShutterSound after the default constuctor
causes application crash.

Bug: 80498247
Test: Manually modify the code to return MODE_IGNORED for
      AppOpsService#checkAudioOperation() and to return false for
      CameraManager#supportsCamera2ApiLocked. Then start voice call in
      Hangouts.

Change-Id: Id738c4d46a8e3625bc3b1142b11acac9cfb0b603
Merged-In: Id738c4d46a8e3625bc3b1142b11acac9cfb0b603
(cherry picked from commit cb63c640cdc8e95a76408a2e90048d9c0dee06de)